### PR TITLE
Added setEncoding for non-UTF databases

### DIFF
--- a/src/SybaseDB.js
+++ b/src/SybaseDB.js
@@ -49,7 +49,7 @@ Sybase.prototype.connect = function(callback)
 		that.connected = true;
 
 		// set up normal listeners.		
-		that.javaDB.stdout.pipe(that.jsonParser).on("data", function(jsonMsg) { that.onSQLResponse.call(that, jsonMsg); });
+		that.javaDB.stdout.setEncoding('utf8').pipe(that.jsonParser).on("data", function(jsonMsg) { that.onSQLResponse.call(that, jsonMsg); });
 		that.javaDB.stderr.on("data", function(err) { that.onSQLError.call(that, err); });
 
 		callback(null, data);


### PR DESCRIPTION
Since the module is not properly handling databases not using JSON compatible encoding (UTF in any of its forms), the JSON parser throws an uncaught exception when obtaining results from a query.

Setting the encoding to UTF-8 on the stdout stream fixes this issue.

E.g.
`Error: Invalid JSON (Invalid UTF-8 character at position 42114 in state STRING1)
    at Parser.proto.write (..\node_modules\jsonparse\jsonparse.js:170:31)
    at Stream.<anonymous> (..\node_modules\JSONStream\index.js:23:12)
    at Stream.stream.write (..\node_modules\through\index.js:26:11)
    at Socket.ondata (_stream_readable.js:557:20)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:191:7)
    at readableAddChunk (_stream_readable.js:178:18)
    at Socket.Readable.push (_stream_readable.js:136:10)
    at Pipe.onread (net.js:561:20)`