### PR TITLE
Bug: Check connection before executing query

### DIFF
--- a/src/SybaseDB.js
+++ b/src/SybaseDB.js
@@ -76,7 +76,7 @@ Sybase.prototype.isConnected = function()
 
 Sybase.prototype.query = function(sql, callback) 
 {
-    if (this.isConnected === false)
+    if (this.isConnected() === false)
     {
     	callback(new Error("database isn't connected."));
     	return;


### PR DESCRIPTION
The current code checks if the _function_ `isConnected` `===` `false`, which doesn't really make much sense. :)